### PR TITLE
feat: add screen-aware layout cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,33 @@ layout:setLayouts({
 
 You can then cycle between these variants with `selectNextVariant()` (see [available methods](#available-action-methods) below).
 
+### Targeting Multiple Screens
+
+By default, each cell is resolved against Hammerspoon's main screen. To target a specific screen, replace a cell string with a table containing `cell` and `screen`:
+
+```lua
+layout:setLayouts({
+  {
+    name = 'Desk Setup',
+    cells = {
+      { cell = '0,0 32x20', screen = 'Built-in Retina Display' },
+      { cell = '32,0 28x20', screen = hs.screen.find('DELL U2720Q') },
+      {
+        { cell = '0,0 60x20', screen = 'Built-in Retina Display' },
+        { cell = '0,0 60x20', screen = hs.screen.find('DELL U2720Q') },
+      },
+    },
+    apps = {
+      WezTerm = { cell = 1, open = true },
+      Brave = { cell = 2, open = true },
+      Slack = { cell = 3 },
+    },
+  },
+})
+```
+
+Single-screen configs remain valid. Screen-aware cells are optional and can be mixed with string cells inside the same layout.
+
 ## Available Action Methods
 
 | Method | Params | Description |

--- a/README.md
+++ b/README.md
@@ -105,7 +105,24 @@ You can then cycle between these variants with `selectNextVariant()` (see [avail
 
 ### Targeting Multiple Screens
 
-By default, each cell is resolved against Hammerspoon's main screen. To target a specific screen, replace a cell string with a table containing `cell` and `screen`:
+By default, each cell is resolved against Hammerspoon's main screen. To target a specific screen, replace a cell string with a table containing `cell` and `screen`.
+
+The `screen` value may be:
+- a display name
+- a display UUID
+- an `hs.screen` object
+
+This is fully opt-in. Existing string-only cells and existing variant arrays continue to work unchanged.
+
+```lua
+-- Legacy single-screen cell (still valid)
+'0,0 32x20'
+
+-- Screen-aware single cell
+{ cell = '0,0 32x20', screen = 'Built-in Retina Display' }
+```
+
+Screen-aware cells can also be used inside variant arrays:
 
 ```lua
 layout:setLayouts({

--- a/grid.lua
+++ b/grid.lua
@@ -27,8 +27,26 @@ end
 
 local min,max = math.min,math.max
 
+local function findScreenByExactName(screenName)
+  for _, candidate in ipairs(screen.allScreens()) do
+    if candidate:name() == screenName then
+      return candidate
+    end
+  end
+end
+
+function M.resolveScreen(scr)
+  local resolved = screen.find(scr)
+
+  if resolved ~= nil or type(scr) ~= 'string' then
+    return resolved
+  end
+
+  return findScreenByExactName(scr)
+end
+
 function M.getCellWithMargins(cell, scr)
-  scr=screen.find(scr)
+  scr=M.resolveScreen(scr)
   if not scr then scr=hs.screen.mainScreen() end
   cell=geom.new(cell)
   local screenrect = grid.getGridFrame(scr)

--- a/helpers.lua
+++ b/helpers.lua
@@ -3,6 +3,7 @@ local M = {}
 -- Extra grid helper, which maybe we can PR to hammerspoon and/or remove later.
 M.grid = dofile(hs.spoons.resourcePath('grid.lua'))
 
+-- Legacy cells are strings, while screen-aware cells opt into a keyed table.
 local function isScreenAwareCell(cell)
   return type(cell) == "table" and (cell.cell ~= nil or cell.screen ~= nil)
 end

--- a/helpers.lua
+++ b/helpers.lua
@@ -3,6 +3,40 @@ local M = {}
 -- Extra grid helper, which maybe we can PR to hammerspoon and/or remove later.
 M.grid = dofile(hs.spoons.resourcePath('grid.lua'))
 
+local function isScreenAwareCell(cell)
+  return type(cell) == "table" and (cell.cell ~= nil or cell.screen ~= nil)
+end
+
+local function normalizeCellVariants(cell)
+  if type(cell) == "string" then
+    return { cell }
+  end
+
+  if isScreenAwareCell(cell) then
+    return { cell }
+  end
+
+  return cell
+end
+
+local function resolveScreen(screenRef)
+  if screenRef == nil then
+    return nil
+  end
+
+  return hs.screen.find(screenRef) or screenRef
+end
+
+local function resolveCellVariant(layout, cell, state)
+  local variant = layout.cells[cell][state.current_layout_variant]
+
+  if isScreenAwareCell(variant) then
+    return variant.cell, resolveScreen(variant.screen)
+  end
+
+  return variant, nil
+end
+
 -- Apply layout.
 function M.applyLayout(key, variant, state)
   if key then state.current_layout_key = key end
@@ -47,12 +81,14 @@ end
 
 -- Apply single layout element for use in hs.layout.apply.
 function M.normalizeElementForApply(app_id, window, cell, layout, state)
+  local cellVariant, screen = resolveCellVariant(layout, cell, state)
+
   return {
     app_id,
     window,
     nil,
     nil,
-    M.grid.getCellWithMargins(layout.cells[cell][state.current_layout_variant]),
+    M.grid.getCellWithMargins(cellVariant, screen),
   }
 end
 
@@ -125,7 +161,7 @@ function M.normalizeLayouts(layouts)
   for layoutKey,layout in ipairs(layouts or {}) do
     local cells = {}
     for _,cell in ipairs(layout.cells or {}) do
-      table.insert(cells, type(cell) == "string" and { cell } or cell)
+      table.insert(cells, normalizeCellVariants(cell))
     end
     normalized[layoutKey].cells = cells
   end

--- a/helpers.lua
+++ b/helpers.lua
@@ -87,7 +87,7 @@ function M.normalizeElementForApply(app_id, window, cell, layout, state)
   return {
     app_id,
     window,
-    nil,
+    screen,
     nil,
     M.grid.getCellWithMargins(cellVariant, screen),
   }

--- a/helpers.lua
+++ b/helpers.lua
@@ -25,11 +25,12 @@ local function resolveScreen(screenRef)
     return nil
   end
 
-  return hs.screen.find(screenRef) or screenRef
+  return M.grid.resolveScreen(screenRef) or screenRef
 end
 
 local function resolveCellVariant(layout, cell, state)
-  local variant = layout.cells[cell][state.current_layout_variant]
+  local variants = layout.cells[cell]
+  local variant = variants[state.current_layout_variant] or variants[1]
 
   if isScreenAwareCell(variant) then
     return variant.cell, resolveScreen(variant.screen)

--- a/tests/helpers_spec.lua
+++ b/tests/helpers_spec.lua
@@ -111,19 +111,24 @@ helpers.applyLayout(1, 1, state)
 
 assert(byAppId(captured, 'term')[5].cell == '0,0 30x20', 'legacy string cells should still normalize')
 assert(byAppId(captured, 'term')[5].screen == 'MAIN', 'legacy string cells should still resolve to the main screen')
+assert(byAppId(captured, 'term')[3] == nil, 'legacy string cells should not force a display override')
 
 assert(byAppId(captured, 'browser')[5].cell == '30,0 30x20', 'legacy variant arrays should still normalize')
 assert(byAppId(captured, 'browser')[5].screen == 'MAIN', 'legacy variant arrays should still resolve to the main screen')
+assert(byAppId(captured, 'browser')[3] == nil, 'legacy variant arrays should not force a display override')
 
 assert(byAppId(captured, 'slack')[5].cell == '0,0 15x20', 'screen-aware cells should resolve nested cell values')
 assert(byAppId(captured, 'slack')[5].screen == 'SCREEN<UUID-1>', 'screen-aware cells should resolve target screens')
+assert(byAppId(captured, 'slack')[3] == 'SCREEN<UUID-1>', 'screen-aware cells should pass the target display to hs.layout.apply')
 
 assert(byAppId(captured, 'obsidian')[5].cell == '0,0 20x20', 'screen-aware variant arrays should resolve correctly')
 assert(byAppId(captured, 'obsidian')[5].screen == 'SCREEN<External Display>', 'screen-aware variant arrays should resolve screen refs')
+assert(byAppId(captured, 'obsidian')[3] == 'SCREEN<External Display>', 'screen-aware variant arrays should pass the resolved display through')
 
 helpers.applyLayout(1, 2, state)
 
 assert(byAppId(captured, 'obsidian')[5].cell == '20,0 40x20', 'mixed variant arrays should still allow plain string variants')
 assert(byAppId(captured, 'obsidian')[5].screen == 'MAIN', 'plain string variants should still fall back to the main screen')
+assert(byAppId(captured, 'obsidian')[3] == nil, 'plain string variants should not set an explicit display')
 
 print('helpers_spec ok')

--- a/tests/helpers_spec.lua
+++ b/tests/helpers_spec.lua
@@ -1,0 +1,129 @@
+package.path = './?.lua;' .. package.path
+
+local geometry = {
+  new = function(cell) return { raw = cell } end,
+  type = function() return 'size' end,
+  size = function(x, y) return { w = x, h = y } end,
+}
+
+setmetatable(geometry, {
+  __call = function(_, value)
+    return value
+  end,
+})
+
+local captured = {}
+
+hs = {
+  spoons = {
+    resourcePath = function(name)
+      return './' .. name
+    end,
+  },
+  screen = {
+    mainScreen = function() return 'MAIN' end,
+    find = function(ref)
+      if ref == 'UUID-1' or ref == 'External Display' then
+        return 'SCREEN<' .. tostring(ref) .. '>'
+      end
+
+      return nil
+    end,
+  },
+  layout = {
+    apply = function(elements)
+      captured = elements
+    end,
+  },
+  application = {
+    open = function() return nil end,
+    get = function() return nil end,
+  },
+  window = {
+    visibleWindows = function() return {} end,
+  },
+  fnutils = {
+    find = function() return nil end,
+  },
+  geometry = geometry,
+  grid = {
+    getGridFrame = function() return { x = 0, y = 0, w = 600, h = 200 } end,
+    getGrid = function() return { w = 60, h = 20 } end,
+    setMargins = function() end,
+  },
+}
+
+package.loaded['hs.grid'] = hs.grid
+package.loaded['hs.geometry'] = hs.geometry
+package.loaded['hs.screen'] = hs.screen
+
+local helpers = dofile('./helpers.lua')
+helpers.grid.getCellWithMargins = function(cell, screen)
+  return {
+    cell = cell,
+    screen = screen or 'MAIN',
+  }
+end
+
+local function byAppId(elements, appId)
+  for _, element in ipairs(elements or {}) do
+    if element[1] == appId then
+      return element
+    end
+  end
+
+  return nil
+end
+
+local state = {
+  current_layout_key = 1,
+  current_layout_variant = 1,
+  layouts = helpers.normalizeLayouts({
+    {
+      name = 'Compatibility',
+      cells = {
+        '0,0 30x20',
+        { '30,0 30x20', '0,0 60x20' },
+        { cell = '0,0 15x20', screen = 'UUID-1' },
+        {
+          { cell = '0,0 20x20', screen = 'External Display' },
+          '20,0 40x20',
+        },
+      },
+      apps = {
+        Terminal = { cell = 1 },
+        Browser = { cell = 2 },
+        Slack = { cell = 3 },
+        Obsidian = { cell = 4 },
+      },
+    },
+  }),
+  apps = {
+    Terminal = { id = 'term' },
+    Browser = { id = 'browser' },
+    Slack = { id = 'slack' },
+    Obsidian = { id = 'obsidian' },
+  },
+  layout_customizations = {},
+}
+
+helpers.applyLayout(1, 1, state)
+
+assert(byAppId(captured, 'term')[5].cell == '0,0 30x20', 'legacy string cells should still normalize')
+assert(byAppId(captured, 'term')[5].screen == 'MAIN', 'legacy string cells should still resolve to the main screen')
+
+assert(byAppId(captured, 'browser')[5].cell == '30,0 30x20', 'legacy variant arrays should still normalize')
+assert(byAppId(captured, 'browser')[5].screen == 'MAIN', 'legacy variant arrays should still resolve to the main screen')
+
+assert(byAppId(captured, 'slack')[5].cell == '0,0 15x20', 'screen-aware cells should resolve nested cell values')
+assert(byAppId(captured, 'slack')[5].screen == 'SCREEN<UUID-1>', 'screen-aware cells should resolve target screens')
+
+assert(byAppId(captured, 'obsidian')[5].cell == '0,0 20x20', 'screen-aware variant arrays should resolve correctly')
+assert(byAppId(captured, 'obsidian')[5].screen == 'SCREEN<External Display>', 'screen-aware variant arrays should resolve screen refs')
+
+helpers.applyLayout(1, 2, state)
+
+assert(byAppId(captured, 'obsidian')[5].cell == '20,0 40x20', 'mixed variant arrays should still allow plain string variants')
+assert(byAppId(captured, 'obsidian')[5].screen == 'MAIN', 'plain string variants should still fall back to the main screen')
+
+print('helpers_spec ok')

--- a/tests/helpers_spec.lua
+++ b/tests/helpers_spec.lua
@@ -1,16 +1,82 @@
 package.path = './?.lua;' .. package.path
 
+local function parseCell(value)
+  local x, y, w, h = value:match('^(%-?[%d%.]+),(%-?[%d%.]+)%s+([%d%.]+)x([%d%.]+)$')
+
+  if not x then
+    return nil
+  end
+
+  return {
+    x = tonumber(x),
+    y = tonumber(y),
+    w = tonumber(w),
+    h = tonumber(h),
+  }
+end
+
+local function parseSize(value)
+  local w, h = value:match('^([%d%.]+)x([%d%.]+)$')
+
+  if not w then
+    return nil
+  end
+
+  return {
+    w = tonumber(w),
+    h = tonumber(h),
+  }
+end
+
 local geometry = {
-  new = function(cell) return { raw = cell } end,
-  type = function() return 'size' end,
+  new = function(value)
+    if type(value) ~= 'string' then
+      return value
+    end
+
+    return parseCell(value) or parseSize(value)
+  end,
+  type = function(value)
+    if type(value) ~= 'table' then
+      return nil
+    end
+
+    if value.x ~= nil and value.y ~= nil and value.w ~= nil and value.h ~= nil then
+      return 'rect'
+    end
+
+    if value.w ~= nil and value.h ~= nil then
+      return 'size'
+    end
+
+    return nil
+  end,
   size = function(x, y) return { w = x, h = y } end,
 }
 
 setmetatable(geometry, {
   __call = function(_, value)
-    return value
+    return geometry.new(value)
   end,
 })
+
+local function newScreen(name, uuid, frame)
+  return {
+    _name = name,
+    _uuid = uuid,
+    _frame = frame,
+    name = function(self) return self._name end,
+    getUUID = function(self) return self._uuid end,
+  }
+end
+
+local screens = {
+  main = newScreen('Main Display', 'UUID-MAIN', { x = 0, y = 0, w = 600, h = 200 }),
+  external = newScreen('External Display', 'UUID-1', { x = 600, y = 0, w = 600, h = 200 }),
+  builtIn = newScreen('Built-in Retina Display', 'UUID-BUILTIN', { x = 1200, y = 0, w = 600, h = 200 }),
+}
+
+local allScreens = { screens.main, screens.external, screens.builtIn }
 
 local captured = {}
 
@@ -21,10 +87,40 @@ hs = {
     end,
   },
   screen = {
-    mainScreen = function() return 'MAIN' end,
+    allScreens = function()
+      return allScreens
+    end,
+    mainScreen = function()
+      return screens.main
+    end,
     find = function(ref)
-      if ref == 'UUID-1' or ref == 'External Display' then
-        return 'SCREEN<' .. tostring(ref) .. '>'
+      if ref == nil then
+        return nil
+      end
+
+      if type(ref) == 'table' then
+        for _, screen in ipairs(allScreens) do
+          if screen == ref then
+            return screen
+          end
+        end
+
+        return nil
+      end
+
+      if type(ref) == 'string' then
+        local needle = ref:lower()
+
+        for _, screen in ipairs(allScreens) do
+          if screen:getUUID() == ref then
+            return screen
+          end
+
+          local name = screen:name()
+          if name and name:lower():find(needle) then
+            return screen
+          end
+        end
       end
 
       return nil
@@ -47,7 +143,9 @@ hs = {
   },
   geometry = geometry,
   grid = {
-    getGridFrame = function() return { x = 0, y = 0, w = 600, h = 200 } end,
+    getGridFrame = function(screen)
+      return screen._frame
+    end,
     getGrid = function() return { w = 60, h = 20 } end,
     setMargins = function() end,
   },
@@ -58,12 +156,6 @@ package.loaded['hs.geometry'] = hs.geometry
 package.loaded['hs.screen'] = hs.screen
 
 local helpers = dofile('./helpers.lua')
-helpers.grid.getCellWithMargins = function(cell, screen)
-  return {
-    cell = cell,
-    screen = screen or 'MAIN',
-  }
-end
 
 local function byAppId(elements, appId)
   for _, element in ipairs(elements or {}) do
@@ -86,7 +178,7 @@ local state = {
         { '30,0 30x20', '0,0 60x20' },
         { cell = '0,0 15x20', screen = 'UUID-1' },
         {
-          { cell = '0,0 20x20', screen = 'External Display' },
+          { cell = '0,0 20x20', screen = 'Built-in Retina Display' },
           '20,0 40x20',
         },
       },
@@ -107,28 +199,26 @@ local state = {
   layout_customizations = {},
 }
 
+local builtInFrame = helpers.grid.getCellWithMargins('0,0 20x20', 'Built-in Retina Display')
+assert(builtInFrame.x == 1205, 'literal display names should resolve exact screens when computing frames')
+
 helpers.applyLayout(1, 1, state)
 
-assert(byAppId(captured, 'term')[5].cell == '0,0 30x20', 'legacy string cells should still normalize')
-assert(byAppId(captured, 'term')[5].screen == 'MAIN', 'legacy string cells should still resolve to the main screen')
+assert(byAppId(captured, 'term')[5].x == 5, 'legacy string cells should still compute against the main screen')
 assert(byAppId(captured, 'term')[3] == nil, 'legacy string cells should not force a display override')
 
-assert(byAppId(captured, 'browser')[5].cell == '30,0 30x20', 'legacy variant arrays should still normalize')
-assert(byAppId(captured, 'browser')[5].screen == 'MAIN', 'legacy variant arrays should still resolve to the main screen')
+assert(byAppId(captured, 'browser')[5].x == 302.5, 'legacy variant arrays should still normalize')
 assert(byAppId(captured, 'browser')[3] == nil, 'legacy variant arrays should not force a display override')
 
-assert(byAppId(captured, 'slack')[5].cell == '0,0 15x20', 'screen-aware cells should resolve nested cell values')
-assert(byAppId(captured, 'slack')[5].screen == 'SCREEN<UUID-1>', 'screen-aware cells should resolve target screens')
-assert(byAppId(captured, 'slack')[3] == 'SCREEN<UUID-1>', 'screen-aware cells should pass the target display to hs.layout.apply')
+assert(byAppId(captured, 'slack')[5].x == 605, 'screen-aware cells should compute against UUID-matched screens')
+assert(byAppId(captured, 'slack')[3] == screens.external, 'screen-aware cells should pass the resolved display to hs.layout.apply')
 
-assert(byAppId(captured, 'obsidian')[5].cell == '0,0 20x20', 'screen-aware variant arrays should resolve correctly')
-assert(byAppId(captured, 'obsidian')[5].screen == 'SCREEN<External Display>', 'screen-aware variant arrays should resolve screen refs')
-assert(byAppId(captured, 'obsidian')[3] == 'SCREEN<External Display>', 'screen-aware variant arrays should pass the resolved display through')
+assert(byAppId(captured, 'obsidian')[5].x == 1205, 'screen-aware variant arrays should honor literal display names with Lua pattern chars')
+assert(byAppId(captured, 'obsidian')[3] == screens.builtIn, 'screen-aware variant arrays should pass exact-name displays through as screen objects')
 
 helpers.applyLayout(1, 2, state)
 
-assert(byAppId(captured, 'obsidian')[5].cell == '20,0 40x20', 'mixed variant arrays should still allow plain string variants')
-assert(byAppId(captured, 'obsidian')[5].screen == 'MAIN', 'plain string variants should still fall back to the main screen')
+assert(byAppId(captured, 'obsidian')[5].x == 202.5, 'mixed variant arrays should still allow plain string variants')
 assert(byAppId(captured, 'obsidian')[3] == nil, 'plain string variants should not set an explicit display')
 
 print('helpers_spec ok')


### PR DESCRIPTION
## Summary
- allow layout cells to optionally include a `screen` target alongside the existing grid `cell`
- preserve exact display-name targets when the name contains Lua pattern characters
- keep legacy string-only cells and variant arrays working unchanged, including single-variant cells when cycling layout variants
- document the multi-screen configuration shape in the README
- add a plain-Lua regression spec that exercises real frame calculation for UUID, exact-name, and legacy cells

## Compatibility
- layouts only become screen-aware when a cell is explicitly written as `{ cell = '...', screen = ... }`
- when `screen` is omitted, cells still resolve against Hammerspoon's main screen
- display names, display UUIDs, and `hs.screen` objects remain accepted screen forms
- mixed layouts continue to support plain string cells alongside screen-aware cells
- cells with only one variant now fall back to variant 1 when a later layout variant is selected

## Testing
- `luac -p helpers.lua init.lua grid.lua state.lua events.lua tests/helpers_spec.lua`
- `lua tests/helpers_spec.lua`

## Notes
- screen resolution is now shared between `helpers.lua` and `grid.lua` so `hs.layout.apply()` and frame calculation resolve the same target display
- the regression case covered here is the README-style `Built-in Retina Display` example, which previously fell back to the main screen during frame calculation because `hs.screen.find()` treats string hints as Lua patterns
